### PR TITLE
Move from hatchling to uv_build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,5 +82,5 @@ cmd = "uv run pytest"
 help = "Run Pytest for unit tests"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.7.20,<0.8.0"]
+build-backend = "uv_build"


### PR DESCRIPTION
Because uv will use its built-in uv_build, so we don't need to download as much.