### PR TITLE
Exit with a non-zero status if we create files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ ij_yaml_indent_sequence_value = false
 
 [*.md]
 indent_size = unset
+
+[*.py]
+indent_size = 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,9 @@ repos:
   hooks:
   - id: editorconfig-checker
     exclude: LICENSE|^\.idea
+    exclude_types:
+    - python
+    - markdown
 - repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.33.2
   hooks:

--- a/tests/init_hooks/test_config_management.py
+++ b/tests/init_hooks/test_config_management.py
@@ -79,10 +79,10 @@ def test_ensure_pre_commit_config_empty(temp_dir, empty_pre_commit_config):
         yaml.dump(empty_pre_commit_config, f)
 
     # Ensure the pre-commit config
-    success = ensure_pre_commit_config(str(file_path))
+    new_file = ensure_pre_commit_config(str(file_path))
 
     # Check that the operation was successful
-    assert success is True
+    assert new_file is False
 
     # Read the updated config
     with open(file_path) as f:
@@ -110,10 +110,10 @@ def test_ensure_pre_commit_config_partial(
 ):
     """Test that ensure_pre_commit_config correctly updates a partial config."""
     # Ensure the pre-commit config
-    success = ensure_pre_commit_config(str(pre_commit_config_file))
+    new_file = ensure_pre_commit_config(str(pre_commit_config_file))
 
-    # Check that the operation was successful
-    assert success is True
+    # Check that the operation was successful but no file was created
+    assert new_file is False
 
     # Read the updated config
     with open(pre_commit_config_file) as f:
@@ -149,10 +149,10 @@ def test_ensure_pre_commit_config_partial(
 def test_preserve_comments(temp_dir, pre_commit_config_with_comments):
     """Test that comments in pre-commit config files are preserved."""
     # Ensure the pre-commit config
-    success = ensure_pre_commit_config(str(pre_commit_config_with_comments))
+    new_file = ensure_pre_commit_config(str(pre_commit_config_with_comments))
 
-    # Check that the operation was successful
-    assert success is True
+    # Check that the operation was successful but no file was created
+    assert new_file is False
 
     # Read the updated file content
     with open(pre_commit_config_with_comments) as f:
@@ -202,10 +202,10 @@ def test_no_write_when_no_changes(temp_dir, monkeypatch):
     )
 
     # Ensure the pre-commit config
-    success = ensure_pre_commit_config(str(file_path))
+    new_file = ensure_pre_commit_config(str(file_path))
 
-    # Check that the operation was successful
-    assert success is True
+    # Check that no new file was reported
+    assert new_file is False
 
     # Check that write_yaml_file was not called
     mock_write.assert_not_called()
@@ -225,10 +225,10 @@ def test_github_actions_hooks_with_workflows_dir(temp_dir, empty_pre_commit_conf
         yaml.dump(empty_pre_commit_config, f)
 
     # Ensure the pre-commit config
-    success = ensure_pre_commit_config(str(file_path))
+    new_file = ensure_pre_commit_config(str(file_path))
 
-    # Check that the operation was successful
-    assert success is True
+    # Check that the operation was successful but no file was created
+    assert new_file is False
 
     # Read the updated config
     with open(file_path) as f:
@@ -257,10 +257,10 @@ def test_github_actions_hooks_without_workflows_dir(temp_dir, empty_pre_commit_c
         yaml.dump(empty_pre_commit_config, f)
 
     # Ensure the pre-commit config
-    success = ensure_pre_commit_config(str(file_path))
+    new_file = ensure_pre_commit_config(str(file_path))
 
-    # Check that the operation was successful
-    assert success is True
+    # Check that the operation was successful but no file was created
+    assert new_file is False
 
     # Read the updated config
     with open(file_path) as f:
@@ -294,10 +294,10 @@ def test_renovate_hooks_with_renovate_json(temp_dir, empty_pre_commit_config):
         yaml.dump(empty_pre_commit_config, f)
 
     # Ensure the pre-commit config
-    success = ensure_pre_commit_config(str(file_path))
+    new_file = ensure_pre_commit_config(str(file_path))
 
-    # Check that the operation was successful
-    assert success is True
+    # Check that the operation was successful but no file was created
+    assert new_file is False
 
     # Read the updated config
     with open(file_path) as f:
@@ -347,10 +347,10 @@ def test_renovate_hooks_without_renovate_json(temp_dir, empty_pre_commit_config)
         yaml.dump(empty_pre_commit_config, f)
 
     # Ensure the pre-commit config
-    success = ensure_pre_commit_config(str(file_path))
+    new_file = ensure_pre_commit_config(str(file_path))
 
-    # Check that the operation was successful
-    assert success is True
+    # Check that the operation was successful but no file was created
+    assert new_file is False
 
     # Read the updated config
     with open(file_path) as f:

--- a/tests/init_hooks/test_file_operations.py
+++ b/tests/init_hooks/test_file_operations.py
@@ -31,10 +31,10 @@ def test_write_yaml_file(temp_dir):
 
     # Write the config to a file
     file_path = Path(temp_dir) / "test.yaml"
-    success = write_yaml_file(str(file_path), test_config)
+    new_file = write_yaml_file(str(file_path), test_config)
 
     # Check that the write was successful
-    assert success is True
+    assert new_file is True
     assert file_path.exists()
 
     # Read the file back and check the content
@@ -50,10 +50,10 @@ def test_ensure_file_exists_new_file(temp_dir):
     test_content = "Test content\n"
 
     # Ensure the file exists
-    success = ensure_file_exists(str(file_path), test_content)
+    new_file = ensure_file_exists(str(file_path), test_content)
 
     # Check that the operation was successful
-    assert success is True
+    assert new_file is True
     assert file_path.exists()
 
     # Check that the file has the expected content
@@ -72,10 +72,10 @@ def test_ensure_file_exists_existing_file(temp_dir):
 
     # Ensure the file exists
     test_content = "Test content\n"
-    success = ensure_file_exists(str(file_path), test_content)
+    new_file = ensure_file_exists(str(file_path), test_content)
 
-    # Check that the operation was successful
-    assert success is True
+    # Check that the operation was successful but no file was created
+    assert new_file is False
 
     # Check that the file content is unchanged
     with open(file_path) as f:

--- a/tests/init_hooks/test_integration.py
+++ b/tests/init_hooks/test_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for the init-hooks pre-commit hook."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -19,7 +20,9 @@ pytestmark = pytest.mark.change_dir
 def test_main(temp_dir):
     """Test the main function."""
     # Run the main function
-    main()
+    with patch("sys.exit") as mock_exit:
+        main()
+        mock_exit.assert_called_once_with(1)
 
     # Check that the required files exist
     assert Path(temp_dir, ".editorconfig").exists()


### PR DESCRIPTION
Pre-commit will only notice changes to files known by git, so if we introduce new files then we need to explicitly error.