### PR TITLE
Add Cargo hooks for fmt and clippy

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -22,3 +22,16 @@
   language_version: python3.12
   pass_filenames: false
   always_run: true
+- id: cargo-clippy
+  name: Cargo Clippy
+  description: Runs `cargo clippy` with stable Rust
+  entry: /usr/local/cargo/bin/cargo clippy
+  language: docker
+  pass_filenames: false
+  types: [rust]
+- id: cargo-fmt
+  name: Cargo Format
+  description: Runs `cargo fmt` with stable Rust
+  entry: /usr/local/cargo/bin/cargo fmt --
+  language: docker
+  types: [rust]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker.io/rust:1.89.0-slim
+
+RUN rustup component add clippy rustfmt
+
+ENTRYPOINT ["/usr/local/cargo/bin/cargo"]


### PR DESCRIPTION
These use Docker, to avoid needing local hooks and a local Cargo when trying to use pre-commit.